### PR TITLE
add-local-validation-before-push

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -1,6 +1,7 @@
 import * as git from './tools/git.js'
 import * as github from './tools/github.js'
 import * as codebase from './tools/codebase.js'
+import * as validation from './tools/validation.js'
 import * as llm from './llm.js'
 import * as pipeline from './pipeline.js'
 import * as memory from './memory.js'
@@ -55,6 +56,13 @@ export async function run(): Promise<void> {
 			} catch (err) {
 				await gitClient.checkout(['.'])
 				lastError = err instanceof Error ? err.message : String(err)
+				continue
+			}
+
+			const localResult = await validation.validate(config.workspacePath)
+			if (!localResult.passed) {
+				await gitClient.checkout(['.'])
+				lastError = localResult.error ?? 'Local validation failed with unknown error'
 				continue
 			}
 

--- a/src/tools/validation.ts
+++ b/src/tools/validation.ts
@@ -1,0 +1,66 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import logger from '../logger.js'
+
+const execFileAsync = promisify(execFile)
+
+export interface ValidationResult {
+	passed: boolean
+	error?: string
+}
+
+async function runCommand(cmd: string, args: string[], cwd: string): Promise<{ stdout: string; stderr: string }> {
+	return execFileAsync(cmd, args, { cwd, timeout: 120_000 })
+}
+
+export async function typeCheck(workspacePath: string): Promise<ValidationResult> {
+	try {
+		await runCommand('npx', ['tsc', '--noEmit'], workspacePath)
+		logger.info('Type check passed')
+		return { passed: true }
+	} catch (err: unknown) {
+		const message = err instanceof Error ? (err as Error & { stdout?: string; stderr?: string }).stdout || (err as Error & { stdout?: string; stderr?: string }).stderr || err.message : String(err)
+		logger.warn(`Type check failed: ${message.slice(0, 300)}`)
+		return { passed: false, error: `TypeScript type check failed:\n${message}` }
+	}
+}
+
+export async function build(workspacePath: string): Promise<ValidationResult> {
+	try {
+		await runCommand('npx', ['tsc'], workspacePath)
+		logger.info('Build passed')
+		return { passed: true }
+	} catch (err: unknown) {
+		const message = err instanceof Error ? (err as Error & { stdout?: string; stderr?: string }).stdout || (err as Error & { stdout?: string; stderr?: string }).stderr || err.message : String(err)
+		logger.warn(`Build failed: ${message.slice(0, 300)}`)
+		return { passed: false, error: `TypeScript build failed:\n${message}` }
+	}
+}
+
+export async function runTests(workspacePath: string): Promise<ValidationResult> {
+	try {
+		await runCommand('node', ['--experimental-vm-modules', 'node_modules/jest/bin/jest.js', '--passWithNoTests'], workspacePath)
+		logger.info('Tests passed')
+		return { passed: true }
+	} catch (err: unknown) {
+		const message = err instanceof Error ? (err as Error & { stdout?: string; stderr?: string }).stdout || (err as Error & { stdout?: string; stderr?: string }).stderr || err.message : String(err)
+		logger.warn(`Tests failed: ${message.slice(0, 300)}`)
+		return { passed: false, error: `Jest tests failed:\n${message}` }
+	}
+}
+
+export async function validate(workspacePath: string): Promise<ValidationResult> {
+	logger.info('Running local validation (type check, build, tests)...')
+
+	const typeResult = await typeCheck(workspacePath)
+	if (!typeResult.passed) return typeResult
+
+	const buildResult = await build(workspacePath)
+	if (!buildResult.passed) return buildResult
+
+	const testResult = await runTests(workspacePath)
+	if (!testResult.passed) return testResult
+
+	logger.info('Local validation passed')
+	return { passed: true }
+}


### PR DESCRIPTION
Add local TypeScript compilation and Jest test execution before pushing changes to GitHub. This will catch syntax errors, type errors, and test failures early, reducing the number of failed PRs and speeding up the iteration cycle.

Create a new tools/validation.ts module with functions to:
1. Run TypeScript compilation (tsc --noEmit for type checking)
2. Run the build (tsc to compile to dist/)
3. Run Jest tests on the compiled output
4. Return detailed error information if any step fails

Integrate this validation into the main loop.ts after applying edits but before the first commit/push. If validation fails, treat it as an error and retry with the PatchSession.fixPatch() flow, similar to how CI failures are handled.

This improvement will make future iterations faster and more reliable by catching errors locally before they reach CI.