### PR TITLE
add-http-client-tool

### DIFF
--- a/src/tools/http.test.ts
+++ b/src/tools/http.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { httpFetch } from "./http";
+import { createServer, IncomingMessage, ServerResponse, Server } from "node:http";
+import { AddressInfo } from "node:net";
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    const url = req.url ?? "/";
+
+    if (url === "/ok") {
+      res.writeHead(200, { "Content-Type": "text/plain", "X-Custom": "test-value" });
+      res.end("hello world");
+    } else if (url === "/json") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: "ok" }));
+    } else if (url === "/echo" && req.method === "POST") {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString();
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end(body);
+      });
+    } else if (url === "/not-found") {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("not found");
+    } else if (url === "/slow") {
+      // Delay longer than our test timeout
+      setTimeout(() => {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("slow response");
+      }, 5000);
+    } else {
+      res.writeHead(400);
+      res.end("bad request");
+    }
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+});
+
+describe("httpFetch", () => {
+  it("should fetch a successful text response", async () => {
+    const response = await httpFetch(`${baseUrl}/ok`);
+
+    expect(response.status).toBe(200);
+    expect(response.ok).toBe(true);
+    expect(response.body).toBe("hello world");
+    expect(response.headers["content-type"]).toBe("text/plain");
+    expect(response.headers["x-custom"]).toBe("test-value");
+  });
+
+  it("should fetch a JSON response as text", async () => {
+    const response = await httpFetch(`${baseUrl}/json`);
+
+    expect(response.status).toBe(200);
+    expect(response.ok).toBe(true);
+    expect(JSON.parse(response.body)).toEqual({ message: "ok" });
+    expect(response.headers["content-type"]).toBe("application/json");
+  });
+
+  it("should handle POST requests with a body", async () => {
+    const response = await httpFetch(`${baseUrl}/echo`, {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: "request body content",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("request body content");
+  });
+
+  it("should handle non-2xx responses without throwing", async () => {
+    const response = await httpFetch(`${baseUrl}/not-found`);
+
+    expect(response.status).toBe(404);
+    expect(response.ok).toBe(false);
+    expect(response.body).toBe("not found");
+  });
+
+  it("should throw on timeout", async () => {
+    await expect(
+      httpFetch(`${baseUrl}/slow`, { timeoutMs: 100 }),
+    ).rejects.toThrow(/timed out after 100ms/);
+  });
+
+  it("should throw on network error (invalid URL)", async () => {
+    await expect(
+      httpFetch("http://127.0.0.1:1/nonexistent"),
+    ).rejects.toThrow();
+  });
+
+  it("should use GET method by default", async () => {
+    const response = await httpFetch(`${baseUrl}/ok`);
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/tools/http.test.ts
+++ b/src/tools/http.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "node:test";
+import assert from "node:assert";
 import { httpFetch } from "./http";
 import { createServer, IncomingMessage, ServerResponse, Server } from "node:http";
 import { AddressInfo } from "node:net";

--- a/src/tools/http.ts
+++ b/src/tools/http.ts
@@ -59,14 +59,16 @@ export async function httpFetch(
       ok: response.ok,
     };
   } catch (error: unknown) {
-    if (error instanceof DOMException && error.name === "AbortError") {
+    const errMsg = error instanceof Error ? error.message : String(error);
+    const errName = error instanceof Error ? error.name : "";
+    if (errName === "AbortError" || errMsg.includes("aborted")) {
       throw new Error(`Request to ${url} timed out after ${timeoutMs}ms`);
     }
     if (error instanceof TypeError) {
-      throw new Error(`Network error fetching ${url}: ${error.message}`);
+      throw new Error(`Network error fetching ${url}: ${errMsg}`);
     }
     throw new Error(
-      `Failed to fetch ${url}: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to fetch ${url}: ${errMsg}`,
     );
   } finally {
     clearTimeout(timeoutId);

--- a/src/tools/http.ts
+++ b/src/tools/http.ts
@@ -1,0 +1,74 @@
+/**
+ * Basic HTTP client tool for fetching content from URLs.
+ * Uses Node's native fetch (Node 18+) with error handling and timeout support.
+ */
+
+export interface HttpResponse {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string;
+  ok: boolean;
+}
+
+export interface HttpRequestOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Fetch content from a URL with error handling and timeout support.
+ *
+ * @param url - The URL to fetch
+ * @param options - Optional request configuration
+ * @returns A normalized HttpResponse
+ */
+export async function httpFetch(
+  url: string,
+  options: HttpRequestOptions = {},
+): Promise<HttpResponse> {
+  const { method = "GET", headers, body, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      method,
+      headers,
+      body,
+      signal: controller.signal,
+    });
+
+    const responseHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      responseHeaders[key] = value;
+    });
+
+    const responseBody = await response.text();
+
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+      body: responseBody,
+      ok: response.ok,
+    };
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error(`Request to ${url} timed out after ${timeoutMs}ms`);
+    }
+    if (error instanceof TypeError) {
+      throw new Error(`Network error fetching ${url}: ${error.message}`);
+    }
+    throw new Error(
+      `Failed to fetch ${url}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}


### PR DESCRIPTION
Add a basic HTTP client tool (src/tools/http.ts) that enables fetching content from URLs. This is the foundation for future capabilities like API integrations, web scraping, and external data access. The tool will:

1. Export a `fetch` function that wraps Node's native fetch with error handling
2. Include timeout support (30 second default)
3. Return response status, headers, and body
4. Handle common errors gracefully
5. Include basic tests (src/tools/http.test.ts)

This is a minimal, focused addition that doesn't modify existing code - only creates new files. No dependencies needed since Node 18+ has native fetch support.