### PR TITLE
add-evolution-analytics-tools

### DIFF
--- a/src/analytics.test.ts
+++ b/src/analytics.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from '@jest/globals'
+import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import mongoose from 'mongoose'
+import GeneratedModel from './models/Generated.js'
+import UsageModel from './models/Usage.js'
+import * as analytics from './analytics.js'
+
+let replSet: MongoMemoryReplSet
+
+beforeAll(async () => {
+	replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
+	await mongoose.connect(replSet.getUri())
+})
+
+afterAll(async () => {
+	await mongoose.disconnect()
+	await replSet.stop()
+})
+
+describe('analytics', () => {
+	beforeEach(async () => {
+		await GeneratedModel.deleteMany({})
+		await UsageModel.deleteMany({})
+	})
+
+	describe('queryIterations', () => {
+		it('returns formatted iterations', async () => {
+			await GeneratedModel.create({
+				planTitle: 'test-change',
+				outcome: 'PR #1 merged successfully after 1 attempt(s).',
+				plannerTranscript: 'planning...',
+				builderTranscript: 'building...',
+				reflection: 'It worked well.',
+			})
+
+			const result = await analytics.queryIterations(10)
+			expect(result).toContain('test-change')
+			expect(result).toContain('merged successfully')
+			expect(result).toContain('It worked well')
+		})
+
+		it('filters by success outcome', async () => {
+			await GeneratedModel.create({
+				planTitle: 'success-change',
+				outcome: 'PR #1 merged successfully',
+				plannerTranscript: 'p1',
+				builderTranscript: 'b1',
+				reflection: 'good',
+			})
+			await GeneratedModel.create({
+				planTitle: 'failure-change',
+				outcome: 'Failed after 4 attempts',
+				plannerTranscript: 'p2',
+				builderTranscript: 'b2',
+				reflection: 'bad',
+			})
+
+			const result = await analytics.queryIterations(10, 'success')
+			expect(result).toContain('success-change')
+			expect(result).not.toContain('failure-change')
+		})
+
+		it('filters by failure outcome', async () => {
+			await GeneratedModel.create({
+				planTitle: 'success-change',
+				outcome: 'merged successfully',
+				plannerTranscript: 'p1',
+				builderTranscript: 'b1',
+				reflection: 'good',
+			})
+			await GeneratedModel.create({
+				planTitle: 'failure-change',
+				outcome: 'Failed after 4 attempts',
+				plannerTranscript: 'p2',
+				builderTranscript: 'b2',
+				reflection: 'bad',
+			})
+
+			const result = await analytics.queryIterations(10, 'failure')
+			expect(result).toContain('failure-change')
+			expect(result).not.toContain('success-change')
+		})
+
+		it('returns empty message when no results', async () => {
+			const result = await analytics.queryIterations(10)
+			expect(result).toBe('No iterations found matching the criteria.')
+		})
+	})
+
+	describe('queryUsageTrends', () => {
+		it('returns summary and entries', async () => {
+			await UsageModel.create({
+				planTitle: 'test-1',
+				totalCalls: 5,
+				totalInputTokens: 1000,
+				totalOutputTokens: 500,
+				totalCost: 0.05,
+				breakdown: [{ caller: 'planner', model: 'claude-haiku-4-5', calls: 3, inputTokens: 600, outputTokens: 300, cost: 0.03 }],
+			})
+
+			const result = await analytics.queryUsageTrends(10)
+			expect(result).toContain('Summary')
+			expect(result).toContain('Total cost: $0.050')
+			expect(result).toContain('test-1')
+			expect(result).toContain('1500 tokens')
+		})
+
+		it('returns empty message when no data', async () => {
+			const result = await analytics.queryUsageTrends(10)
+			expect(result).toBe('No usage data available.')
+		})
+	})
+
+	describe('searchReflections', () => {
+		it('finds reflections by keyword', async () => {
+			await GeneratedModel.create({
+				planTitle: 'test-1',
+				outcome: 'success',
+				plannerTranscript: 'p',
+				builderTranscript: 'b',
+				reflection: 'The change was too ambitious and broke tests.',
+			})
+			await GeneratedModel.create({
+				planTitle: 'test-2',
+				outcome: 'success',
+				plannerTranscript: 'p',
+				builderTranscript: 'b',
+				reflection: 'Simple refactor went smoothly.',
+			})
+
+			const result = await analytics.searchReflections('ambitious', 5)
+			expect(result).toContain('test-1')
+			expect(result).toContain('too ambitious')
+			expect(result).not.toContain('test-2')
+		})
+
+		it('returns empty message when no matches', async () => {
+			const result = await analytics.searchReflections('nonexistent', 5)
+			expect(result).toContain('No reflections matching')
+		})
+	})
+})

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,0 +1,77 @@
+import GeneratedModel from './models/Generated.js'
+import UsageModel from './models/Usage.js'
+
+export async function queryIterations(limit: number = 10, outcomeFilter?: 'success' | 'failure'): Promise<string> {
+	// Build query filter
+	const query: Record<string, unknown> = {}
+	if (outcomeFilter === 'success') {
+		query.outcome = { $regex: /merged successfully|passed/i }
+	} else if (outcomeFilter === 'failure') {
+		query.outcome = { $regex: /failed|error/i }
+	}
+	
+	// Query with limit
+	const iterations = await GeneratedModel
+		.find(query)
+		.sort({ createdAt: -1 })
+		.limit(Math.min(limit, 50))
+		.select('planTitle outcome reflection createdAt')
+		.lean()
+	
+	if (iterations.length === 0) {
+		return 'No iterations found matching the criteria.'
+	}
+	
+	// Format results
+	return iterations.map(it => {
+		const date = new Date(it.createdAt).toISOString().slice(0, 19).replace('T', ' ')
+		return `[${date}] "${it.planTitle}"\nOutcome: ${it.outcome}\nReflection: ${it.reflection}\n`
+	}).join('\n---\n\n')
+}
+
+export async function queryUsageTrends(limit: number = 10): Promise<string> {
+	const usages = await UsageModel
+		.find({})
+		.sort({ createdAt: -1 })
+		.limit(Math.min(limit, 50))
+		.select('planTitle totalCost totalInputTokens totalOutputTokens totalCalls createdAt breakdown')
+		.lean()
+	
+	if (usages.length === 0) {
+		return 'No usage data available.'
+	}
+	
+	// Calculate summary stats
+	const totalCost = usages.reduce((sum, u) => sum + u.totalCost, 0)
+	const avgCost = totalCost / usages.length
+	const totalTokens = usages.reduce((sum, u) => sum + u.totalInputTokens + u.totalOutputTokens, 0)
+	
+	// Format individual entries
+	const entries = usages.map(u => {
+		const date = new Date(u.createdAt).toISOString().slice(0, 10)
+		const models = [...new Set(u.breakdown.map(b => b.model))].join(', ')
+		return `[${date}] "${u.planTitle}": $${u.totalCost.toFixed(3)} (${u.totalInputTokens + u.totalOutputTokens} tokens, ${u.totalCalls} calls) [${models}]`
+	}).join('\n')
+	
+	return `Summary (last ${usages.length} iterations):\n- Total cost: $${totalCost.toFixed(3)}\n- Average cost per iteration: $${avgCost.toFixed(3)}\n- Total tokens: ${totalTokens.toLocaleString()}\n\n${entries}`
+}
+
+export async function searchReflections(query: string, limit: number = 5): Promise<string> {
+	// Use regex search on reflection field
+	const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+	const iterations = await GeneratedModel
+		.find({ reflection: new RegExp(escaped, 'i') })
+		.sort({ createdAt: -1 })
+		.limit(Math.min(limit, 20))
+		.select('planTitle reflection createdAt')
+		.lean()
+	
+	if (iterations.length === 0) {
+		return `No reflections matching "${query}".`
+	}
+	
+	return iterations.map(it => {
+		const date = new Date(it.createdAt).toISOString().slice(0, 19).replace('T', ' ')
+		return `[${date}] After "${it.planTitle}":\n${it.reflection}`
+	}).join('\n\n---\n\n')
+}


### PR DESCRIPTION
Add analytics tools that let SeedGPT query its own evolution history stored in MongoDB. This adds three new planner tools: `query_iterations` to retrieve recent iterations with filtering by outcome, `query_usage_trends` to analyze API cost and token usage over time, and `search_reflections` to find past self-reflections by keyword. These tools enable data-driven planning by surfacing patterns in successes, failures, and resource consumption.