### PR TITLE
add-historical-iteration-recall

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -320,13 +320,14 @@ export interface PlanResult {
 	messages: Anthropic.MessageParam[]
 }
 
-export async function plan(recentMemory: string, codebaseContext: string, gitLog: string): Promise<PlanResult> {
+export async function plan(recentMemory: string, codebaseContext: string, gitLog: string, iterationHistory: string): Promise<PlanResult> {
 	logger.info('Asking LLM for a plan...')
 
 	const tools = PLANNER_TOOLS
+	const historySection = iterationHistory ? `\n\n## Past Iterations\n\n${iterationHistory}` : ''
 	const messages: Anthropic.MessageParam[] = [{
 		role: 'user',
-		content: `${recentMemory}\n\n${codebaseContext}\n\n## Recent Git History\n${gitLog}\n\nReview your notes and recent memories, then submit your plan.`,
+		content: `${recentMemory}\n\n${codebaseContext}\n\n## Recent Git History\n${gitLog}${historySection}\n\nReview your notes and recent memories, then submit your plan.`,
 	}]
 
 	const system = cachedSystem(SYSTEM_PLAN)

--- a/src/loop.test.ts
+++ b/src/loop.test.ts
@@ -52,6 +52,7 @@ jest.unstable_mockModule('./tools/codebase.js', () => ({
 
 jest.unstable_mockModule('./memory.js', () => ({
 	getContext: jest.fn<() => Promise<string>>().mockResolvedValue('No memories yet. This is your first run.'),
+	getIterationHistory: jest.fn<() => Promise<string>>().mockResolvedValue(''),
 	store: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
 }))
 

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -27,6 +27,7 @@ export async function run(): Promise<void> {
 		// learns from the failure, and tries a different approach.
 		while (!merged) {
 			const recentMemory = await memory.getContext()
+			const iterationHistory = await memory.getIterationHistory()
 			const [fileTree, declarationIndex, depGraph] = await Promise.all([
 				codebase.getFileTree(config.workspacePath),
 				codebase.getDeclarationIndex(config.workspacePath),
@@ -36,7 +37,7 @@ export async function run(): Promise<void> {
 			const codebaseContext = `## File Tree\n\`\`\`\n${fileTree}\n\`\`\`\n\n## Dependency Graph\n${depGraph}\n\n## Declarations\n${declarationIndex}`
 			const gitLog = await git.getRecentLog(gitClient)
 
-			const { plan, messages: plannerMessages } = await llm.plan(recentMemory, codebaseContext, gitLog)
+			const { plan, messages: plannerMessages } = await llm.plan(recentMemory, codebaseContext, gitLog, iterationHistory)
 			await memory.store(`Planned change "${plan.title}": ${plan.description}`)
 
 			const session = new llm.PatchSession(plan, recentMemory)


### PR DESCRIPTION
Add ability to query and learn from past iterations. Currently, iteration outcomes and reflections are stored in MongoDB but never retrieved during planning. This change adds a function to fetch recent iteration history and includes it in the planning context, enabling learning from past successes and failures.