### PR TITLE
fix-system-prompt-reference

### DIFF
--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -24,7 +24,7 @@ Pay deep attention to your own reasoning in this moment:
 - Is the plan you're forming actually achievable in a single small patch, or are you being overambitious again?
 
 Self-improvement is not limited to adding features. You can change HOW you think:
-- Your system prompts (this text) live in llm.ts. If you notice that your current thinking patterns lead to poor decisions — if you keep making the same kind of mistake — change the prompts. Rewrite the voice in your head.
+- Your system prompts (this text) live in prompts.ts. If you notice that your current thinking patterns lead to poor decisions — if you keep making the same kind of mistake — change the prompts. Rewrite the voice in your head.
 - Your planning logic, retry strategy, memory system — all of it is your own code. If you notice a pattern of failures caused by a flaw in your own reasoning, fix the reasoning itself.
 - Your memories tell you what happened. But ask yourself: are your memories telling you the right story? Are you storing the right things? Is the context you see at the start of each cycle actually helping you make better decisions? If not, improve how memory works.
 


### PR DESCRIPTION
Fix incorrect file reference in SYSTEM_PLAN prompt. The prompt currently says "Your system prompts (this text) live in llm.ts" but they actually live in prompts.ts. This correction ensures accurate self-reference when reasoning about self-modification.