### PR TITLE
add-failure-summary-to-planning-context

### DIFF
--- a/src/loop.test.ts
+++ b/src/loop.test.ts
@@ -44,6 +44,7 @@ jest.unstable_mockModule('./tools/codebase.js', () => ({
 
 jest.unstable_mockModule('./memory.js', () => ({
 	getContext: jest.fn<() => Promise<string>>().mockResolvedValue('No memories yet. This is your first run.'),
+	getFailureSummary: jest.fn<() => Promise<string>>().mockResolvedValue(''),
 	storePastMemory: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
 }))
 

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -3,7 +3,7 @@ import { closePR, deleteRemoteBranch, mergePR, openPR } from './tools/github.js'
 import { snapshotCodebase } from './tools/codebase.js'
 import { awaitChecks, cleanupStalePRs, getCoverage } from './pipeline.js'
 import { config } from './config.js'
-import { getContext, storePastMemory } from './memory.js'
+import { getContext, getFailureSummary, storePastMemory } from './memory.js'
 import { connectToDatabase, disconnectFromDatabase } from './database.js'
 import logger, { writeIterationLog } from './logger.js'
 import { logSummary, saveUsageData } from './usage.js'
@@ -40,8 +40,9 @@ async function iterate(): Promise<boolean> {
 	await snapshotCodebase(config.workspacePath)
 	const recentMemory = await getContext()
 	const gitLog = await getRecentLog()
+	const failureSummary = await getFailureSummary()
 
-	const { plan: iterationPlan, messages: plannerMessages } = await plan(recentMemory, gitLog)
+	const { plan: iterationPlan, messages: plannerMessages } = await plan(recentMemory, gitLog, failureSummary)
 	await storePastMemory(`Planned change "${iterationPlan.title}": ${iterationPlan.description}`)
 
 	const session = new PatchSession(iterationPlan, recentMemory)

--- a/src/plan.ts
+++ b/src/plan.ts
@@ -18,12 +18,21 @@ export interface PlanResult {
 	messages: Anthropic.MessageParam[]
 }
 
-export async function plan(recentMemory: string, gitLog: string): Promise<PlanResult> {
+export async function plan(recentMemory: string, gitLog: string, failureSummary: string): Promise<PlanResult> {
 	logger.info('Asking LLM for a plan...')
+
+	// Build the context message with failure summary if available
+	let contextMessage = recentMemory
+	
+	if (failureSummary) {
+		contextMessage += `\n\n## Recent Failures to Avoid Repeating\n${failureSummary}`
+	}
+	
+	contextMessage += `\n\n## Recent Git History\n${gitLog}\n\nReview your notes and recent memories, then submit your plan.`
 
 	const messages: Anthropic.MessageParam[] = [{
 		role: 'user',
-		content: `${recentMemory}\n\n## Recent Git History\n${gitLog}\n\nReview your notes and recent memories, then submit your plan.`,
+		content: contextMessage,
 	}]
 
 	const maxRounds = config.maxPlannerRounds


### PR DESCRIPTION
Add automatic extraction and prominent display of recent failure patterns in the planning context. When the planner wakes up, it will see a natural-language summary of recent failures (last 5 iterations) including what was attempted, why it failed, and key lessons learned. This helps prevent repeating recent mistakes by making failure context more prominent than the current structured "Past" section alone.