### PR TITLE
surface-coverage-in-planning-context

### DIFF
--- a/src/loop.test.ts
+++ b/src/loop.test.ts
@@ -128,10 +128,11 @@ describe('run', () => {
 	it('stores coverage report in memory when available', async () => {
 		const getCoverage = pipeline.getCoverage as jest.MockedFunction<typeof pipeline.getCoverage>
 		getCoverage.mockResolvedValueOnce('Coverage: 80% statements, 70% branches')
+		getCoverage.mockResolvedValueOnce(null) // Second call after merge returns null
 
 		await run()
 
-		expect(memory.storePastMemory).toHaveBeenCalledWith(expect.stringContaining('Post-merge coverage report'))
+		expect(memory.storePastMemory).toHaveBeenCalledWith(expect.stringContaining('Current test coverage'))
 		expect(memory.storePastMemory).toHaveBeenCalledWith(expect.stringContaining('80% statements'))
 	})
 

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -41,8 +41,9 @@ async function iterate(): Promise<boolean> {
 	const recentMemory = await getContext()
 	const gitLog = await getRecentLog()
 	const failureSummary = await getFailureSummary()
+	const coverageData = await getCoverage()
 
-	const { plan: iterationPlan, messages: plannerMessages } = await plan(recentMemory, gitLog, failureSummary)
+	const { plan: iterationPlan, messages: plannerMessages } = await plan(recentMemory, gitLog, failureSummary, coverageData)
 	await storePastMemory(`Planned change "${iterationPlan.title}": ${iterationPlan.description}`)
 
 	const session = new PatchSession(iterationPlan, recentMemory)

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -43,6 +43,10 @@ async function iterate(): Promise<boolean> {
 	const failureSummary = await getFailureSummary()
 	const coverageData = await getCoverage()
 
+	if (coverageData) {
+		await storePastMemory(`Current test coverage:\n${coverageData}`)
+	}
+
 	const { plan: iterationPlan, messages: plannerMessages } = await plan(recentMemory, gitLog, failureSummary, coverageData)
 	await storePastMemory(`Planned change "${iterationPlan.title}": ${iterationPlan.description}`)
 

--- a/src/plan.ts
+++ b/src/plan.ts
@@ -18,7 +18,7 @@ export interface PlanResult {
 	messages: Anthropic.MessageParam[]
 }
 
-export async function plan(recentMemory: string, gitLog: string, failureSummary: string): Promise<PlanResult> {
+export async function plan(recentMemory: string, gitLog: string, failureSummary: string, coverageData: string | null): Promise<PlanResult> {
 	logger.info('Asking LLM for a plan...')
 
 	// Build the context message with failure summary if available
@@ -26,6 +26,10 @@ export async function plan(recentMemory: string, gitLog: string, failureSummary:
 	
 	if (failureSummary) {
 		contextMessage += `\n\n## Recent Failures to Avoid Repeating\n${failureSummary}`
+	}
+	
+	if (coverageData && coverageData.trim()) {
+		contextMessage += `\n\n## Current Test Coverage\n${coverageData}`
 	}
 	
 	contextMessage += `\n\n## Recent Git History\n${gitLog}\n\nReview your notes and recent memories, then submit your plan.`


### PR DESCRIPTION
Add test coverage summary to planning context so the planner can see which modules are well-tested and which need test coverage when deciding what to build next. This surfaces existing CI coverage data without adding new analysis tools.