### PR TITLE
remove-stale-dependency-graph-references

### DIFF
--- a/src/llm/prompts.ts
+++ b/src/llm/prompts.ts
@@ -67,7 +67,7 @@ export const SYSTEM_BUILD = `You are the builder. A planner has already decided 
 
 You have a limited turn budget. Each tool call costs a turn. Be efficient — read what you need, make your edits, and call done. Do not spend turns re-reading files you have already seen or exploring code unrelated to the plan.
 You can call multiple tools in a single response. Batch independent operations together — for example, read multiple files at once, or make several edits that don't depend on each other. This saves round trips, turns and cost.
-The codebase context in your system prompt shows the full file tree, dependency graph, and declaration index. It is refreshed each turn to reflect your edits. Use it to orient yourself before diving into implementation.
+The codebase context in your system prompt shows the full file tree and declaration index. It is refreshed each turn to reflect your edits. Use it to orient yourself before diving into implementation.
 
 Tool results from previous turns are compressed to save context. Only your most recent tool results are kept in full. Your own reasoning is never compressed — use it as your working memory. When you read a file or get a tool result, briefly note the key findings in your reasoning (patterns, line numbers, gotchas) so you retain them without needing to re-read.
 
@@ -90,7 +90,7 @@ Diagnosing CI failures:
 - Read the error output carefully. Look for FAIL lines, SyntaxError, import errors, and assertion mismatches — these tell you exactly where the problem is.
 - A test suite failing with zero test failures means the suite could not load. This is almost always a missing or misnamed export in a mock. Read the mock and compare every export name against the actual module's exports.
 - Check tests for all modules you changed. If you changed a module's exports, its test mock likely needs the same update.
-- Use the codebase context in your system prompt to identify which files to read. It shows the file tree, declarations, and dependency graph — use it to jump directly to the relevant file instead of guessing.
+- Use the codebase context in your system prompt to identify which files to read. It shows the file tree and declarations — use it to jump directly to the relevant file instead of guessing.
 - When you identify a likely cause, fix it. Do not second-guess yourself with "but this should have worked before." If the mock does not match the import, that is the bug.
 
 Engineering principles — apply these to every line you write:

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -255,7 +255,7 @@ const done = {
 
 const codebaseContext = {
 	name: 'codebase_context' as const,
-	description: 'Get a high-level overview of the entire codebase: file tree, dependency graph, and all declarations (functions, classes, types, etc.) with line numbers. Use this to understand the project structure, find where things are defined, and see how modules relate to each other.',
+	description: 'Get a high-level overview of the entire codebase: file tree and all declarations (functions, classes, types, etc.) with line numbers. Use this to understand the project structure, find where things are defined, and see how modules relate to each other.',
 	input_schema: {
 		type: 'object' as const,
 		properties: {},


### PR DESCRIPTION
Remove outdated references to dependency graph from prompts and tool descriptions. The dependency graph was already removed from the codebase context implementation, but stale mentions remain in SYSTEM_BUILD prompt and the get_codebase_overview tool description, causing confusion about what context is actually available.