### PR TITLE
add-performance-metrics-tool

### DIFF
--- a/src/tools/metrics.test.ts
+++ b/src/tools/metrics.test.ts
@@ -1,13 +1,13 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals'
 
 // Mock mongoose models
-const mockGeneratedFind = jest.fn()
-const mockGeneratedCountDocuments = jest.fn()
-const mockGeneratedDistinct = jest.fn()
+const mockGeneratedFind = jest.fn<any>()
+const mockGeneratedCountDocuments = jest.fn<any>()
+const mockGeneratedDistinct = jest.fn<any>()
 
-const mockMemoryFind = jest.fn()
+const mockMemoryFind = jest.fn<any>()
 
-const mockIterationLogFind = jest.fn()
+const mockIterationLogFind = jest.fn<any>()
 
 jest.unstable_mockModule('../models/Generated.js', () => ({
 	default: {
@@ -15,7 +15,7 @@ jest.unstable_mockModule('../models/Generated.js', () => ({
 		countDocuments: mockGeneratedCountDocuments,
 		distinct: mockGeneratedDistinct,
 	},
-	computeCost: jest.fn(),
+	computeCost: jest.fn<any>(),
 }))
 
 jest.unstable_mockModule('../models/Memory.js', () => ({
@@ -44,8 +44,8 @@ describe('queryPerformanceMetrics', () => {
 			
 			// Mock aggregate for cost sum
 			mockGeneratedFind.mockReturnValue({
-				select: jest.fn().mockReturnValue({
-					exec: jest.fn().mockResolvedValue([
+				select: jest.fn<any>().mockReturnValue({
+					exec: jest.fn<any>().mockResolvedValue([
 						{ cost: 1.5 },
 						{ cost: 2.0 },
 						{ cost: 0.5 },
@@ -54,8 +54,8 @@ describe('queryPerformanceMetrics', () => {
 			})
 
 			mockMemoryFind.mockReturnValue({
-				select: jest.fn().mockReturnValue({
-					exec: jest.fn().mockResolvedValue([
+				select: jest.fn<any>().mockReturnValue({
+					exec: jest.fn<any>().mockResolvedValue([
 						{ content: 'Successfully completed task' },
 						{ content: 'Failed to build' },
 					]),
@@ -75,13 +75,13 @@ describe('queryPerformanceMetrics', () => {
 			mockGeneratedCountDocuments.mockResolvedValue(0)
 			mockGeneratedDistinct.mockResolvedValue([])
 			mockGeneratedFind.mockReturnValue({
-				select: jest.fn().mockReturnValue({
-					exec: jest.fn().mockResolvedValue([]),
+				select: jest.fn<any>().mockReturnValue({
+					exec: jest.fn<any>().mockResolvedValue([]),
 				}),
 			})
 			mockMemoryFind.mockReturnValue({
-				select: jest.fn().mockReturnValue({
-					exec: jest.fn().mockResolvedValue([]),
+				select: jest.fn<any>().mockReturnValue({
+					exec: jest.fn<any>().mockResolvedValue([]),
 				}),
 			})
 
@@ -125,10 +125,10 @@ describe('queryPerformanceMetrics', () => {
 			]
 
 			mockGeneratedFind.mockReturnValue({
-				sort: jest.fn().mockReturnValue({
-					limit: jest.fn().mockReturnValue({
-						select: jest.fn().mockReturnValue({
-							exec: jest.fn().mockResolvedValue(mockData),
+				sort: jest.fn<any>().mockReturnValue({
+					limit: jest.fn<any>().mockReturnValue({
+						select: jest.fn<any>().mockReturnValue({
+							exec: jest.fn<any>().mockResolvedValue(mockData),
 						}),
 					}),
 				}),
@@ -144,14 +144,14 @@ describe('queryPerformanceMetrics', () => {
 		})
 
 		it('should respect the limit parameter', async () => {
-			const mockLimit = jest.fn().mockReturnValue({
-				select: jest.fn().mockReturnValue({
-					exec: jest.fn().mockResolvedValue([]),
+			const mockLimit = jest.fn<any>().mockReturnValue({
+				select: jest.fn<any>().mockReturnValue({
+					exec: jest.fn<any>().mockResolvedValue([]),
 				}),
 			})
 
 			mockGeneratedFind.mockReturnValue({
-				sort: jest.fn().mockReturnValue({
+				sort: jest.fn<any>().mockReturnValue({
 					limit: mockLimit,
 				}),
 			})
@@ -175,9 +175,9 @@ describe('queryPerformanceMetrics', () => {
 			]
 
 			mockIterationLogFind.mockReturnValue({
-				sort: jest.fn().mockReturnValue({
-					limit: jest.fn().mockReturnValue({
-						exec: jest.fn().mockResolvedValue(mockLogs),
+				sort: jest.fn<any>().mockReturnValue({
+					limit: jest.fn<any>().mockReturnValue({
+						exec: jest.fn<any>().mockResolvedValue(mockLogs),
 					}),
 				}),
 			})
@@ -191,9 +191,9 @@ describe('queryPerformanceMetrics', () => {
 
 		it('should handle no iterations', async () => {
 			mockIterationLogFind.mockReturnValue({
-				sort: jest.fn().mockReturnValue({
-					limit: jest.fn().mockReturnValue({
-						exec: jest.fn().mockResolvedValue([]),
+				sort: jest.fn<any>().mockReturnValue({
+					limit: jest.fn<any>().mockReturnValue({
+						exec: jest.fn<any>().mockResolvedValue([]),
 					}),
 				}),
 			})
@@ -220,10 +220,10 @@ describe('queryPerformanceMetrics', () => {
 			]
 
 			mockMemoryFind.mockReturnValue({
-				sort: jest.fn().mockReturnValue({
-					limit: jest.fn().mockReturnValue({
-						select: jest.fn().mockReturnValue({
-							exec: jest.fn().mockResolvedValue(mockReflections),
+				sort: jest.fn<any>().mockReturnValue({
+					limit: jest.fn<any>().mockReturnValue({
+						select: jest.fn<any>().mockReturnValue({
+							exec: jest.fn<any>().mockResolvedValue(mockReflections),
 						}),
 					}),
 				}),
@@ -238,10 +238,10 @@ describe('queryPerformanceMetrics', () => {
 
 		it('should handle no reflections', async () => {
 			mockMemoryFind.mockReturnValue({
-				sort: jest.fn().mockReturnValue({
-					limit: jest.fn().mockReturnValue({
-						select: jest.fn().mockReturnValue({
-							exec: jest.fn().mockResolvedValue([]),
+				sort: jest.fn<any>().mockReturnValue({
+					limit: jest.fn<any>().mockReturnValue({
+						select: jest.fn<any>().mockReturnValue({
+							exec: jest.fn<any>().mockResolvedValue([]),
 						}),
 					}),
 				}),

--- a/src/tools/metrics.test.ts
+++ b/src/tools/metrics.test.ts
@@ -1,0 +1,264 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+// Mock mongoose models
+const mockGeneratedFind = jest.fn()
+const mockGeneratedCountDocuments = jest.fn()
+const mockGeneratedDistinct = jest.fn()
+
+const mockMemoryFind = jest.fn()
+
+const mockIterationLogFind = jest.fn()
+
+jest.unstable_mockModule('../models/Generated.js', () => ({
+	default: {
+		find: mockGeneratedFind,
+		countDocuments: mockGeneratedCountDocuments,
+		distinct: mockGeneratedDistinct,
+	},
+	computeCost: jest.fn(),
+}))
+
+jest.unstable_mockModule('../models/Memory.js', () => ({
+	default: {
+		find: mockMemoryFind,
+	},
+}))
+
+jest.unstable_mockModule('../models/IterationLog.js', () => ({
+	default: {
+		find: mockIterationLogFind,
+	},
+}))
+
+const { queryPerformanceMetrics } = await import('./metrics.js')
+
+beforeEach(() => {
+	jest.clearAllMocks()
+})
+
+describe('queryPerformanceMetrics', () => {
+	describe('summary metric', () => {
+		it('should return overall statistics', async () => {
+			mockGeneratedCountDocuments.mockResolvedValue(150)
+			mockGeneratedDistinct.mockResolvedValue(['iter1', 'iter2', 'iter3'])
+			
+			// Mock aggregate for cost sum
+			mockGeneratedFind.mockReturnValue({
+				select: jest.fn().mockReturnValue({
+					exec: jest.fn().mockResolvedValue([
+						{ cost: 1.5 },
+						{ cost: 2.0 },
+						{ cost: 0.5 },
+					]),
+				}),
+			})
+
+			mockMemoryFind.mockReturnValue({
+				select: jest.fn().mockReturnValue({
+					exec: jest.fn().mockResolvedValue([
+						{ content: 'Successfully completed task' },
+						{ content: 'Failed to build' },
+					]),
+				}),
+			})
+
+			const result = await queryPerformanceMetrics('summary')
+
+			expect(result).toContain('150')
+			expect(result).toContain('3')
+			expect(result).toContain('4.00')
+			expect(mockGeneratedCountDocuments).toHaveBeenCalled()
+			expect(mockGeneratedDistinct).toHaveBeenCalledWith('iterationId')
+		})
+
+		it('should handle empty database gracefully', async () => {
+			mockGeneratedCountDocuments.mockResolvedValue(0)
+			mockGeneratedDistinct.mockResolvedValue([])
+			mockGeneratedFind.mockReturnValue({
+				select: jest.fn().mockReturnValue({
+					exec: jest.fn().mockResolvedValue([]),
+				}),
+			})
+			mockMemoryFind.mockReturnValue({
+				select: jest.fn().mockReturnValue({
+					exec: jest.fn().mockResolvedValue([]),
+				}),
+			})
+
+			const result = await queryPerformanceMetrics('summary')
+
+			expect(result).toContain('0')
+			expect(result).toContain('first iteration')
+		})
+
+		it('should handle database errors', async () => {
+			mockGeneratedCountDocuments.mockRejectedValue(new Error('Database connection failed'))
+
+			const result = await queryPerformanceMetrics('summary')
+
+			expect(result).toContain('Error')
+			expect(result).toContain('Database connection failed')
+		})
+	})
+
+	describe('token_usage metric', () => {
+		it('should return recent token usage data', async () => {
+			const mockData = [
+				{
+					iterationId: 'iter1',
+					phase: 'planner',
+					inputTokens: 1000,
+					outputTokens: 500,
+					cacheReadTokens: 200,
+					cost: 0.5,
+					createdAt: new Date('2024-01-01'),
+				},
+				{
+					iterationId: 'iter1',
+					phase: 'builder',
+					inputTokens: 2000,
+					outputTokens: 1000,
+					cacheReadTokens: 300,
+					cost: 1.0,
+					createdAt: new Date('2024-01-01'),
+				},
+			]
+
+			mockGeneratedFind.mockReturnValue({
+				sort: jest.fn().mockReturnValue({
+					limit: jest.fn().mockReturnValue({
+						select: jest.fn().mockReturnValue({
+							exec: jest.fn().mockResolvedValue(mockData),
+						}),
+					}),
+				}),
+			})
+
+			const result = await queryPerformanceMetrics('token_usage', 10)
+
+			expect(result).toContain('iter1')
+			expect(result).toContain('planner')
+			expect(result).toContain('1000')
+			expect(result).toContain('500')
+			expect(mockGeneratedFind).toHaveBeenCalled()
+		})
+
+		it('should respect the limit parameter', async () => {
+			const mockLimit = jest.fn().mockReturnValue({
+				select: jest.fn().mockReturnValue({
+					exec: jest.fn().mockResolvedValue([]),
+				}),
+			})
+
+			mockGeneratedFind.mockReturnValue({
+				sort: jest.fn().mockReturnValue({
+					limit: mockLimit,
+				}),
+			})
+
+			await queryPerformanceMetrics('token_usage', 5)
+
+			expect(mockLimit).toHaveBeenCalledWith(5)
+		})
+	})
+
+	describe('recent_iterations metric', () => {
+		it('should return recent iteration logs', async () => {
+			const mockLogs = [
+				{
+					entries: [
+						{ timestamp: '2024-01-01T10:00:00Z', level: 'info', message: 'Starting iteration' },
+						{ timestamp: '2024-01-01T10:05:00Z', level: 'error', message: 'Build failed' },
+					],
+					createdAt: new Date('2024-01-01'),
+				},
+			]
+
+			mockIterationLogFind.mockReturnValue({
+				sort: jest.fn().mockReturnValue({
+					limit: jest.fn().mockReturnValue({
+						exec: jest.fn().mockResolvedValue(mockLogs),
+					}),
+				}),
+			})
+
+			const result = await queryPerformanceMetrics('recent_iterations', 5)
+
+			expect(result).toContain('Starting iteration')
+			expect(result).toContain('Build failed')
+			expect(mockIterationLogFind).toHaveBeenCalled()
+		})
+
+		it('should handle no iterations', async () => {
+			mockIterationLogFind.mockReturnValue({
+				sort: jest.fn().mockReturnValue({
+					limit: jest.fn().mockReturnValue({
+						exec: jest.fn().mockResolvedValue([]),
+					}),
+				}),
+			})
+
+			const result = await queryPerformanceMetrics('recent_iterations')
+
+			expect(result).toContain('No iterations')
+		})
+	})
+
+	describe('reflections metric', () => {
+		it('should return recent reflections', async () => {
+			const mockReflections = [
+				{
+					content: 'We need to improve our test coverage strategy',
+					summary: 'Test coverage improvements',
+					createdAt: new Date('2024-01-01'),
+				},
+				{
+					content: 'Build times are increasing',
+					summary: 'Build performance',
+					createdAt: new Date('2023-12-31'),
+				},
+			]
+
+			mockMemoryFind.mockReturnValue({
+				sort: jest.fn().mockReturnValue({
+					limit: jest.fn().mockReturnValue({
+						select: jest.fn().mockReturnValue({
+							exec: jest.fn().mockResolvedValue(mockReflections),
+						}),
+					}),
+				}),
+			})
+
+			const result = await queryPerformanceMetrics('reflections', 10)
+
+			expect(result).toContain('test coverage')
+			expect(result).toContain('Build times')
+			expect(mockMemoryFind).toHaveBeenCalledWith({ category: 'reflection' })
+		})
+
+		it('should handle no reflections', async () => {
+			mockMemoryFind.mockReturnValue({
+				sort: jest.fn().mockReturnValue({
+					limit: jest.fn().mockReturnValue({
+						select: jest.fn().mockReturnValue({
+							exec: jest.fn().mockResolvedValue([]),
+						}),
+					}),
+				}),
+			})
+
+			const result = await queryPerformanceMetrics('reflections')
+
+			expect(result).toContain('No reflections')
+		})
+	})
+
+	describe('unknown metric', () => {
+		it('should return error for unknown metric type', async () => {
+			const result = await queryPerformanceMetrics('invalid_metric')
+
+			expect(result).toContain('Unknown metric type')
+			expect(result).toContain('invalid_metric')
+		})
+	})
+})

--- a/src/tools/metrics.ts
+++ b/src/tools/metrics.ts
@@ -1,0 +1,213 @@
+import GeneratedModel from '../models/Generated.js'
+import MemoryModel from '../models/Memory.js'
+import IterationLogModel from '../models/IterationLog.js'
+
+export async function queryPerformanceMetrics(metric: string, limit: number = 10): Promise<string> {
+	try {
+		switch (metric) {
+			case 'summary':
+				return await getSummaryMetrics()
+			case 'token_usage':
+				return await getTokenUsageMetrics(limit)
+			case 'recent_iterations':
+				return await getRecentIterations(limit)
+			case 'reflections':
+				return await getReflections(limit)
+			default:
+				return `Unknown metric type: ${metric}. Available: summary, token_usage, recent_iterations, reflections`
+		}
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err)
+		return `Error querying metrics: ${message}. The database may be unavailable or empty.`
+	}
+}
+
+async function getSummaryMetrics(): Promise<string> {
+	// Count total API calls
+	const totalCalls = await GeneratedModel.countDocuments()
+	
+	if (totalCalls === 0) {
+		return 'No performance data available yet. This appears to be the first iteration.'
+	}
+
+	// Count unique iterations
+	const uniqueIterations = await GeneratedModel.distinct('iterationId')
+	const iterationCount = uniqueIterations.filter(id => id && id !== '').length
+
+	// Calculate total costs
+	const costResult = await GeneratedModel.aggregate([
+		{ $group: { _id: null, totalCost: { $sum: '$cost' } } }
+	])
+	const totalCost = costResult.length > 0 ? costResult[0].totalCost : 0
+
+	// Count reflections with success/failure indicators
+	const reflections = await MemoryModel.find({ 
+		category: 'reflection', 
+		active: true 
+	}).select('content').lean()
+
+	let successCount = 0
+	let failureCount = 0
+	
+	for (const reflection of reflections) {
+		const content = reflection.content.toLowerCase()
+		if (content.includes('success') || content.includes('merged') || content.includes('passed')) {
+			successCount++
+		}
+		if (content.includes('fail') || content.includes('error') || content.includes('reject')) {
+			failureCount++
+		}
+	}
+
+	const totalReflections = reflections.length
+	const successRate = totalReflections > 0 
+		? Math.round((successCount / totalReflections) * 100)
+		: 0
+
+	return `
+=== PERFORMANCE SUMMARY ===
+Total API Calls: ${totalCalls}
+Iterations Logged: ${iterationCount}
+Total Cost: $${totalCost.toFixed(4)}
+Reflections: ${totalReflections} (${successCount} positive, ${failureCount} negative)
+Estimated Success Rate: ${successRate}% (based on reflection sentiment)
+
+Note: Success rate is approximate, based on keyword analysis of reflections.
+`.trim()
+}
+
+async function getTokenUsageMetrics(limit: number): Promise<string> {
+	const records = await GeneratedModel
+		.find()
+		.sort({ createdAt: -1 })
+		.limit(limit)
+		.select('phase iterationId inputTokens outputTokens cacheReadTokens cost createdAt')
+		.lean()
+
+	if (records.length === 0) {
+		return 'No token usage data available yet.'
+	}
+
+	let output = '=== TOKEN USAGE (Recent Activity) ===\n\n'
+	
+	for (const record of records) {
+		const date = new Date(record.createdAt).toISOString().split('T')[0]
+		const time = new Date(record.createdAt).toISOString().split('T')[1].split('.')[0]
+		const cacheInfo = record.cacheReadTokens > 0 ? ` (${record.cacheReadTokens} cached)` : ''
+		
+		output += `${date} ${time} | ${record.phase.padEnd(10)} | `
+		output += `In: ${String(record.inputTokens).padStart(6)} | `
+		output += `Out: ${String(record.outputTokens).padStart(6)}${cacheInfo} | `
+		output += `Cost: $${record.cost.toFixed(4)}\n`
+	}
+
+	// Calculate totals
+	const totalInput = records.reduce((sum, r) => sum + r.inputTokens, 0)
+	const totalOutput = records.reduce((sum, r) => sum + r.outputTokens, 0)
+	const totalCached = records.reduce((sum, r) => sum + r.cacheReadTokens, 0)
+	const totalCost = records.reduce((sum, r) => sum + r.cost, 0)
+
+	output += `\nTotals (last ${records.length} calls):\n`
+	output += `  Input: ${totalInput.toLocaleString()} tokens\n`
+	output += `  Output: ${totalOutput.toLocaleString()} tokens\n`
+	output += `  Cached: ${totalCached.toLocaleString()} tokens\n`
+	output += `  Cost: $${totalCost.toFixed(4)}`
+
+	return output
+}
+
+async function getRecentIterations(limit: number): Promise<string> {
+	const logs = await IterationLogModel
+		.find()
+		.sort({ createdAt: -1 })
+		.limit(limit)
+		.lean()
+
+	if (logs.length === 0) {
+		return 'No iteration logs available yet.'
+	}
+
+	let output = '=== RECENT ITERATIONS ===\n\n'
+
+	for (const log of logs) {
+		const date = new Date(log.createdAt).toISOString().split('T')[0]
+		const time = new Date(log.createdAt).toISOString().split('T')[1].split('.')[0]
+		
+		output += `${date} ${time}\n`
+		
+		// Extract key events from log entries
+		const keyEvents: string[] = []
+		const errors: string[] = []
+		const warnings: string[] = []
+		
+		for (const entry of log.entries) {
+			const msg = entry.message.toLowerCase()
+			
+			if (entry.level === 'error' || msg.includes('error') || msg.includes('fail')) {
+				errors.push(entry.message)
+			} else if (entry.level === 'warn' || msg.includes('warning')) {
+				warnings.push(entry.message)
+			} else if (
+				msg.includes('success') || 
+				msg.includes('merged') || 
+				msg.includes('completed') ||
+				msg.includes('passed')
+			) {
+				keyEvents.push(entry.message)
+			}
+		}
+
+		if (keyEvents.length > 0) {
+			output += `  ✓ Success: ${keyEvents[0]}\n`
+		}
+		if (errors.length > 0) {
+			output += `  ✗ Errors: ${errors.length} found\n`
+			output += `    - ${errors[0].slice(0, 80)}${errors[0].length > 80 ? '...' : ''}\n`
+		}
+		if (warnings.length > 0) {
+			output += `  ⚠ Warnings: ${warnings.length}\n`
+		}
+		if (keyEvents.length === 0 && errors.length === 0 && warnings.length === 0) {
+			output += `  Total log entries: ${log.entries.length}\n`
+		}
+		
+		output += '\n'
+	}
+
+	return output.trim()
+}
+
+async function getReflections(limit: number): Promise<string> {
+	const reflections = await MemoryModel
+		.find({ category: 'reflection' })
+		.sort({ createdAt: -1 })
+		.limit(limit)
+		.select('content summary createdAt active')
+		.lean()
+
+	if (reflections.length === 0) {
+		return 'No reflections available yet.'
+	}
+
+	let output = '=== RECENT REFLECTIONS ===\n\n'
+
+	for (const reflection of reflections) {
+		const date = new Date(reflection.createdAt).toISOString().split('T')[0]
+		const time = new Date(reflection.createdAt).toISOString().split('T')[1].split('.')[0]
+		const status = reflection.active ? '●' : '○'
+		
+		output += `${status} ${date} ${time}\n`
+		
+		// Show summary if available, otherwise first line of content
+		if (reflection.summary) {
+			output += `  ${reflection.summary}\n`
+		} else {
+			const firstLine = reflection.content.split('\n')[0]
+			output += `  ${firstLine.slice(0, 100)}${firstLine.length > 100 ? '...' : ''}\n`
+		}
+		
+		output += '\n'
+	}
+
+	return output.trim()
+}


### PR DESCRIPTION
Add a `query_metrics` tool to the planner phase that allows querying the database for performance analytics including iteration count, success rates, token usage trends, and recent reflection summaries. This enables better self-awareness and data-driven decision making about what to improve next.