### PR TITLE
add-iteration-history-query

### DIFF
--- a/src/tools/history.test.ts
+++ b/src/tools/history.test.ts
@@ -1,0 +1,315 @@
+import { jest, describe, it, expect, beforeAll, afterAll, beforeEach } from '@jest/globals'
+import mongoose from 'mongoose'
+import { MongoMemoryReplSet } from 'mongodb-memory-server'
+
+const { queryIterationHistory } = await import('./history.js')
+const GeneratedModel = (await import('../models/Generated.js')).default
+
+let replSet: MongoMemoryReplSet
+
+beforeAll(async () => {
+	replSet = new MongoMemoryReplSet()
+	await replSet.start()
+	await replSet.waitUntilRunning()
+	await mongoose.connect(replSet.getUri())
+}, 30000)
+
+afterAll(async () => {
+	await mongoose.disconnect()
+	await replSet.stop({ doCleanup: true, force: true })
+})
+
+beforeEach(async () => {
+	await GeneratedModel.deleteMany({})
+})
+
+describe('queryIterationHistory', () => {
+	it('returns formatted summary for multiple iterations', async () => {
+		// Create test data for multiple iterations
+		const now = new Date()
+		const iteration1Id = 'iter-001-abc'
+		const iteration2Id = 'iter-002-def'
+
+		// First iteration - completed (has reflect phase)
+		await GeneratedModel.create({
+			phase: 'planner',
+			modelId: 'test-model',
+			iterationId: iteration1Id,
+			system: [],
+			messages: [
+				{
+					role: 'assistant',
+					content: [
+						{
+							type: 'tool_use',
+							name: 'submit_plan',
+							input: { title: 'Add feature X' },
+						},
+					],
+				},
+			],
+			response: [],
+			inputTokens: 100,
+			outputTokens: 50,
+			cost: 0.01,
+			batch: false,
+			stopReason: 'end_turn',
+			createdAt: new Date(now.getTime() - 2000),
+		})
+
+		await GeneratedModel.create({
+			phase: 'builder',
+			modelId: 'test-model',
+			iterationId: iteration1Id,
+			system: [],
+			messages: [],
+			response: [],
+			inputTokens: 100,
+			outputTokens: 50,
+			cost: 0.01,
+			batch: false,
+			stopReason: 'end_turn',
+			createdAt: new Date(now.getTime() - 1500),
+		})
+
+		await GeneratedModel.create({
+			phase: 'reflect',
+			modelId: 'test-model',
+			iterationId: iteration1Id,
+			system: [],
+			messages: [],
+			response: [],
+			inputTokens: 100,
+			outputTokens: 50,
+			cost: 0.01,
+			batch: false,
+			stopReason: 'end_turn',
+			createdAt: new Date(now.getTime() - 1000),
+		})
+
+		// Second iteration - failed (no reflect phase)
+		await GeneratedModel.create({
+			phase: 'planner',
+			modelId: 'test-model',
+			iterationId: iteration2Id,
+			system: [],
+			messages: [
+				{
+					role: 'user',
+					content: 'Fix the bug in module Y',
+				},
+			],
+			response: [],
+			inputTokens: 100,
+			outputTokens: 50,
+			cost: 0.01,
+			batch: false,
+			stopReason: 'end_turn',
+			createdAt: new Date(now.getTime() - 500),
+		})
+
+		await GeneratedModel.create({
+			phase: 'builder',
+			modelId: 'test-model',
+			iterationId: iteration2Id,
+			system: [],
+			messages: [],
+			response: [],
+			inputTokens: 100,
+			outputTokens: 50,
+			cost: 0.01,
+			batch: false,
+			stopReason: 'end_turn',
+			createdAt: now,
+		})
+
+		const result = await queryIterationHistory(10)
+
+		expect(result).toContain('iter-002')
+		expect(result).toContain('failed')
+		expect(result).toContain('iter-001')
+		expect(result).toContain('completed')
+		expect(result).toContain('Add feature X')
+		
+		// Most recent should come first
+		const lines = result.split('\n')
+		expect(lines[0]).toContain('iter-002')
+		expect(lines[1]).toContain('iter-001')
+	})
+
+	it('handles custom limit parameter', async () => {
+		const now = new Date()
+
+		// Create 3 iterations
+		for (let i = 0; i < 3; i++) {
+			await GeneratedModel.create({
+				phase: 'planner',
+				modelId: 'test-model',
+				iterationId: `iter-${i}`,
+				system: [],
+				messages: [],
+				response: [],
+				inputTokens: 100,
+				outputTokens: 50,
+				cost: 0.01,
+				batch: false,
+				stopReason: 'end_turn',
+				createdAt: new Date(now.getTime() - (3 - i) * 1000),
+			})
+		}
+
+		// Request only 2
+		const result = await queryIterationHistory(2)
+		const lines = result.split('\n')
+		expect(lines.length).toBe(2)
+	})
+
+	it('returns appropriate message when no history exists', async () => {
+		const result = await queryIterationHistory()
+		expect(result).toBe('No iteration history found.')
+	})
+
+	it('correctly identifies completed vs incomplete iterations', async () => {
+		const now = new Date()
+
+		// Complete iteration with reflect phase
+		await GeneratedModel.create({
+			phase: 'planner',
+			modelId: 'test-model',
+			iterationId: 'complete-iter',
+			system: [],
+			messages: [],
+			response: [],
+			inputTokens: 100,
+			outputTokens: 50,
+			cost: 0.01,
+			batch: false,
+			stopReason: 'end_turn',
+			createdAt: new Date(now.getTime() - 2000),
+		})
+
+		await GeneratedModel.create({
+			phase: 'reflect',
+			modelId: 'test-model',
+			iterationId: 'complete-iter',
+			system: [],
+			messages: [],
+			response: [],
+			inputTokens: 100,
+			outputTokens: 50,
+			cost: 0.01,
+			batch: false,
+			stopReason: 'end_turn',
+			createdAt: new Date(now.getTime() - 1000),
+		})
+
+		// Incomplete iteration without reflect phase
+		await GeneratedModel.create({
+			phase: 'planner',
+			modelId: 'test-model',
+			iterationId: 'incomplete-iter',
+			system: [],
+			messages: [],
+			response: [],
+			inputTokens: 100,
+			outputTokens: 50,
+			cost: 0.01,
+			batch: false,
+			stopReason: 'end_turn',
+			createdAt: now,
+		})
+
+		const result = await queryIterationHistory()
+		const lines = result.split('\n')
+
+		const completeLine = lines.find(l => l.includes('complete-iter'))
+		const incompleteLine = lines.find(l => l.includes('incomplete-iter'))
+
+		expect(completeLine).toContain('completed')
+		expect(incompleteLine).toContain('failed')
+	})
+
+	it('extracts description from various message formats', async () => {
+		const now = new Date()
+
+		// Test with tool_use format
+		await GeneratedModel.create({
+			phase: 'planner',
+			modelId: 'test-model',
+			iterationId: 'iter-tool',
+			system: [],
+			messages: [
+				{
+					role: 'assistant',
+					content: [
+						{
+							type: 'tool_use',
+							name: 'submit_plan',
+							input: { title: 'Implement authentication' },
+						},
+					],
+				},
+			],
+			response: [],
+			inputTokens: 100,
+			outputTokens: 50,
+			cost: 0.01,
+			batch: false,
+			stopReason: 'end_turn',
+			createdAt: new Date(now.getTime() - 3000),
+		})
+
+		// Test with text block format
+		await GeneratedModel.create({
+			phase: 'planner',
+			modelId: 'test-model',
+			iterationId: 'iter-text',
+			system: [],
+			messages: [
+				{
+					role: 'assistant',
+					content: [
+						{
+							type: 'text',
+							text: 'Refactor database connection',
+						},
+					],
+				},
+			],
+			response: [],
+			inputTokens: 100,
+			outputTokens: 50,
+			cost: 0.01,
+			batch: false,
+			stopReason: 'end_turn',
+			createdAt: new Date(now.getTime() - 2000),
+		})
+
+		// Test with string format
+		await GeneratedModel.create({
+			phase: 'planner',
+			modelId: 'test-model',
+			iterationId: 'iter-string',
+			system: [],
+			messages: [
+				{
+					role: 'user',
+					content: 'Fix memory leak in worker',
+				},
+			],
+			response: [],
+			inputTokens: 100,
+			outputTokens: 50,
+			cost: 0.01,
+			batch: false,
+			stopReason: 'end_turn',
+			createdAt: new Date(now.getTime() - 1000),
+		})
+
+		const result = await queryIterationHistory(10)
+
+		expect(result).toContain('Implement authentication')
+		expect(result).toContain('Refactor database connection')
+		expect(result).toContain('Fix memory leak in worker')
+	})
+})

--- a/src/tools/history.test.ts
+++ b/src/tools/history.test.ts
@@ -222,8 +222,8 @@ describe('queryIterationHistory', () => {
 		const result = await queryIterationHistory()
 		const lines = result.split('\n')
 
-		const completeLine = lines.find(l => l.includes('complete-iter'))
-		const incompleteLine = lines.find(l => l.includes('incomplete-iter'))
+		const completeLine = lines.find(l => l.includes('complete-iter ['))
+		const incompleteLine = lines.find(l => l.includes('incomplete-iter ['))
 
 		expect(completeLine).toContain('completed')
 		expect(incompleteLine).toContain('failed')

--- a/src/tools/history.ts
+++ b/src/tools/history.ts
@@ -26,7 +26,7 @@ export async function queryIterationHistory(limit: number = 5): Promise<string> 
 
 	const summaries: string[] = []
 	for (const iteration of iterations) {
-		const iterationId = iteration._id.slice(0, 8)
+		const iterationId = iteration._id
 		const date = new Date(iteration.firstCreated).toISOString().slice(0, 19).replace('T', ' ')
 		
 		// Iteration is considered complete if reflect phase exists

--- a/src/tools/history.ts
+++ b/src/tools/history.ts
@@ -1,0 +1,71 @@
+import GeneratedModel from '../models/Generated.js'
+import logger from '../logger.js'
+
+export async function queryIterationHistory(limit: number = 5): Promise<string> {
+	logger.debug(`Querying iteration history with limit ${limit}`)
+
+	// Aggregate to group by iterationId and get phases and timing info
+	const iterations = await GeneratedModel.aggregate([
+		{ $match: { iterationId: { $ne: '' } } },
+		{
+			$group: {
+				_id: '$iterationId',
+				phases: { $addToSet: '$phase' },
+				firstCreated: { $min: '$createdAt' },
+				lastCreated: { $max: '$createdAt' },
+				messages: { $first: '$messages' },
+			},
+		},
+		{ $sort: { firstCreated: -1 } },
+		{ $limit: limit },
+	])
+
+	if (iterations.length === 0) {
+		return 'No iteration history found.'
+	}
+
+	const summaries: string[] = []
+	for (const iteration of iterations) {
+		const iterationId = iteration._id.slice(0, 8)
+		const date = new Date(iteration.firstCreated).toISOString().slice(0, 19).replace('T', ' ')
+		
+		// Iteration is considered complete if reflect phase exists
+		const outcome = iteration.phases.includes('reflect') ? 'completed' : 'failed'
+		
+		// Extract description from planner messages
+		let description = 'Unknown'
+		try {
+			const messages = iteration.messages as Array<{ role: string; content: string | Array<{ type: string; text?: string; name?: string; input?: unknown }> }>
+			for (const msg of messages) {
+				if (typeof msg.content === 'string') {
+					// Simple text content
+					if (msg.content.length > 10) {
+						description = msg.content.slice(0, 100).replace(/\n/g, ' ')
+						break
+					}
+				} else if (Array.isArray(msg.content)) {
+					// Tool use or text blocks
+					for (const block of msg.content) {
+						if (block.type === 'tool_use' && block.name === 'submit_plan') {
+							const input = block.input as { title?: string }
+							if (input?.title) {
+								description = input.title
+								break
+							}
+						} else if (block.type === 'text' && block.text && block.text.length > 10) {
+							description = block.text.slice(0, 100).replace(/\n/g, ' ')
+							break
+						}
+					}
+					if (description !== 'Unknown') break
+				}
+			}
+		} catch (err) {
+			logger.debug(`Could not extract description for iteration ${iterationId}: ${err}`)
+		}
+		
+		summaries.push(`- ${iterationId} [${date}] ${outcome}: ${description}`)
+	}
+
+	return summaries.join('\n')
+}


### PR DESCRIPTION
Add a tool for the planner to query recent iteration history. This enables the planner to detect patterns (e.g., consecutive failures, repeated attempts at similar features) and make more informed decisions about what to work on next. The initial implementation provides a summary of the last 5 iterations showing whether they succeeded or failed and what was attempted.