### PR TITLE
add-list-iterations-tool

### DIFF
--- a/src/agents/memory.test.ts
+++ b/src/agents/memory.test.ts
@@ -24,6 +24,7 @@ jest.unstable_mockModule('../llm/api.js', () => ({
 
 const memory = await import('./memory.js')
 const MemoryModel = (await import('../models/Memory.js')).default
+const IterationLogModel = (await import('../models/IterationLog.js')).default
 
 let replSet: MongoMemoryReplSet
 
@@ -211,8 +212,6 @@ describe('memory', () => {
 	})
 
 	describe('listIterations', () => {
-		const IterationLogModel = (await import('../models/IterationLog.js')).default
-
 		beforeEach(async () => {
 			await IterationLogModel.deleteMany({})
 		})

--- a/src/agents/memory.test.ts
+++ b/src/agents/memory.test.ts
@@ -209,4 +209,81 @@ describe('memory', () => {
 			expect(result).toContain('No memory with id')
 		})
 	})
+
+	describe('listIterations', () => {
+		const IterationLogModel = (await import('../models/IterationLog.js')).default
+
+		beforeEach(async () => {
+			await IterationLogModel.deleteMany({})
+		})
+
+		it('returns formatted list when iterations exist', async () => {
+			await IterationLogModel.create({
+				entries: [
+					{ timestamp: '2025-01-01T12:00:00Z', level: 'info', message: 'Build phase started' },
+					{ timestamp: '2025-01-01T12:05:00Z', level: 'info', message: 'Merged PR #123 successfully' },
+				],
+				createdAt: new Date('2025-01-01T12:00:00Z'),
+			})
+
+			await IterationLogModel.create({
+				entries: [
+					{ timestamp: '2025-01-02T10:00:00Z', level: 'info', message: 'Started new iteration' },
+					{ timestamp: '2025-01-02T10:30:00Z', level: 'error', message: 'Max turns reached, giving up' },
+				],
+				createdAt: new Date('2025-01-02T10:00:00Z'),
+			})
+
+			await IterationLogModel.create({
+				entries: [
+					{ timestamp: '2025-01-03T08:00:00Z', level: 'info', message: 'Iteration started' },
+					{ timestamp: '2025-01-03T08:45:00Z', level: 'error', message: 'CI failed after 3 attempts' },
+				],
+				createdAt: new Date('2025-01-03T08:00:00Z'),
+			})
+
+			const result = await memory.listIterations(10)
+
+			// Should return newest first (descending by createdAt)
+			expect(result).toContain('2025-01-03')
+			expect(result).toContain('2025-01-02')
+			expect(result).toContain('2025-01-01')
+
+			// Should detect different outcomes
+			expect(result).toContain('success')
+			expect(result).toContain('failure')
+		})
+
+		it('respects the limit parameter', async () => {
+			// Create 15 iterations
+			for (let i = 0; i < 15; i++) {
+				await IterationLogModel.create({
+					entries: [{ timestamp: `2025-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`, level: 'info', message: 'Test' }],
+					createdAt: new Date(`2025-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`),
+				})
+			}
+
+			const result = await memory.listIterations(5)
+			const lines = result.split('\n').filter(l => l.trim().length > 0)
+			expect(lines.length).toBe(5)
+		})
+
+		it('returns "No iterations found" when database is empty', async () => {
+			const result = await memory.listIterations(10)
+			expect(result).toBe('No iterations found in database.')
+		})
+
+		it('uses default limit of 10 when not provided', async () => {
+			for (let i = 0; i < 15; i++) {
+				await IterationLogModel.create({
+					entries: [{ timestamp: `2025-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`, level: 'info', message: 'Test' }],
+					createdAt: new Date(`2025-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`),
+				})
+			}
+
+			const result = await memory.listIterations()
+			const lines = result.split('\n').filter(l => l.trim().length > 0)
+			expect(lines.length).toBe(10)
+		})
+	})
 })

--- a/src/tools/definitions.test.ts
+++ b/src/tools/definitions.test.ts
@@ -15,11 +15,14 @@ const mockDismissNote = jest.fn<(...args: unknown[]) => Promise<string>>().mockR
 const mockRecall = jest.fn<(...args: unknown[]) => Promise<string>>().mockResolvedValue('Memory content here.')
 const mockRecallById = jest.fn<(...args: unknown[]) => Promise<string>>().mockResolvedValue('Memory by id content.')
 
+const mockListIterations = jest.fn<(...args: unknown[]) => Promise<string>>().mockResolvedValue('[2025-01-03] 673abc123: success\n[2025-01-02] 673abc122: failure')
+
 jest.unstable_mockModule('../agents/memory.js', () => ({
 	storeNote: mockStoreNote,
 	dismissNote: mockDismissNote,
 	recall: mockRecall,
 	recallById: mockRecallById,
+	listIterations: mockListIterations,
 }))
 
 const mockReadFile = jest.fn<(root: string, path: string) => Promise<string>>()
@@ -230,6 +233,20 @@ describe('handleTool', () => {
 		it('returns message when neither query nor id given', async () => {
 			const result = await handleTool('recall_memory', {}, 'id1')
 			expect(result.content).toContain('Provide a query or id')
+		})
+	})
+
+	describe('list_iterations', () => {
+		it('lists iterations with default limit', async () => {
+			const result = await handleTool('list_iterations', {}, 'id1')
+			expect(mockListIterations).toHaveBeenCalledWith(10)
+			expect(result.content).toContain('[2025-01-03] 673abc123: success')
+		})
+
+		it('respects custom limit parameter', async () => {
+			const result = await handleTool('list_iterations', { limit: 5 }, 'id1')
+			expect(mockListIterations).toHaveBeenCalledWith(5)
+			expect(result.content).toContain('[2025-01-03] 673abc123: success')
 		})
 	})
 


### PR DESCRIPTION
Add a `list_iterations` tool for the planner to query recent iteration history. This tool provides visibility into past iteration outcomes, timestamps, and IDs, helping the planner understand patterns and avoid repeating mistakes. The tool is read-only, simple (single query with optional limit), and follows the same pattern as the existing `recall` memory tool.