### PR TITLE
add-plan-implementation-to-fixer-context

### DIFF
--- a/src/agents/fix.test.ts
+++ b/src/agents/fix.test.ts
@@ -36,6 +36,7 @@ beforeEach(() => {
 const fixContext = {
 	planTitle: 'test-change',
 	planDescription: 'A test change',
+	planImplementation: 'Detailed implementation instructions for the builder',
 	createdFiles: ['new.ts'],
 	modifiedFiles: ['existing.ts'],
 }

--- a/src/agents/fix.ts
+++ b/src/agents/fix.ts
@@ -9,6 +9,7 @@ import { toolLogSuffix } from '../logger.js'
 interface FixContext {
 	planTitle: string
 	planDescription: string
+	planImplementation: string
 	createdFiles: string[]
 	modifiedFiles: string[]
 }
@@ -39,6 +40,8 @@ export class FixSession {
 			`You were implementing "${this.context.planTitle}": ${this.context.planDescription}`,
 			'The changes were applied but CI failed. Diagnose and fix the issue.',
 		]
+
+		sections.push(`## Original Implementation Instructions\n${this.context.planImplementation}`)
 
 		if (this.context.createdFiles.length > 0) {
 			sections.push(`Files CREATED by the builder (entirely new):\n${this.context.createdFiles.map(f => `- ${f}`).join('\n')}`)

--- a/src/loop.test.ts
+++ b/src/loop.test.ts
@@ -153,6 +153,7 @@ describe('run', () => {
 		expect(fixModule.FixSession).toHaveBeenCalledWith({
 			planTitle: 'test-change',
 			planDescription: 'A test change',
+			planImplementation: 'test implementation',
 			createdFiles: ['src/index.test.ts'],
 			modifiedFiles: ['src/index.ts'],
 		})

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -76,6 +76,7 @@ async function iterate(): Promise<boolean> {
 				fixer = new FixSession({
 					planTitle: iterationPlan.title,
 					planDescription: iterationPlan.description,
+					planImplementation: iterationPlan.implementation,
 					createdFiles: created,
 					modifiedFiles: modified,
 				})


### PR DESCRIPTION
Pass the plan's implementation instructions to the fixer so it has better context about what the builder was trying to achieve. This should help the fixer diagnose and fix issues more efficiently by understanding the original architectural intent, potentially reducing the number of fix rounds needed.