### PR TITLE
add-iteration-summary-to-planner-context

### DIFF
--- a/src/agents/analyze.test.ts
+++ b/src/agents/analyze.test.ts
@@ -597,7 +597,7 @@ describe('getRecentIterationSummary', () => {
 		})
 
 		const summary = await getRecentIterationSummary()
-		expect(summary).toContain('2/2 merged')
+		expect(summary).toContain('2 merged')
 		expect(summary).toContain('0 failed')
 	})
 
@@ -625,8 +625,8 @@ describe('getRecentIterationSummary', () => {
 		})
 
 		const summary = await getRecentIterationSummary()
-		expect(summary).toContain('1/1 merged')
-		expect(summary).toContain('1 iter w/ fixes')
+		expect(summary).toContain('1 merged')
+		expect(summary).toContain('1 iterations needed 1+ fix')
 	})
 
 	it('identifies common issue types', async () => {
@@ -670,7 +670,7 @@ describe('getRecentIterationSummary', () => {
 		}
 
 		const summary = await getRecentIterationSummary(5)
-		expect(summary).toContain('5/5 merged')
+		expect(summary).toContain('5 merged')
 	})
 
 	it('handles mixed outcomes correctly', async () => {
@@ -702,8 +702,8 @@ describe('getRecentIterationSummary', () => {
 		})
 
 		const summary = await getRecentIterationSummary()
-		expect(summary).toContain('2/3 merged')
+		expect(summary).toContain('2 merged')
 		expect(summary).toContain('1 failed')
-		expect(summary).toContain('2 iter w/ fixes')
+		expect(summary).toContain('2 iterations needed 1+ fix')
 	})
 })

--- a/src/agents/analyze.ts
+++ b/src/agents/analyze.ts
@@ -79,7 +79,7 @@ export async function getRecentIterationSummary(limit = 10): Promise<string> {
 
 		return parts.join(' | ')
 	} catch (error) {
-		logger.log('error', 'Failed to compute recent iteration summary', { error })
+		logger.error('Failed to compute recent iteration summary', { error })
 		return ''
 	}
 }

--- a/src/llm/api.test.ts
+++ b/src/llm/api.test.ts
@@ -61,6 +61,11 @@ jest.unstable_mockModule('../agents/memory.js', () => ({
 	getMemoryContext: mockGetMemoryContext,
 }))
 
+const mockGetRecentIterationSummary = jest.fn<() => Promise<string>>().mockResolvedValue('')
+jest.unstable_mockModule('../agents/analyze.js', () => ({
+	getRecentIterationSummary: mockGetRecentIterationSummary,
+}))
+
 jest.unstable_mockModule('./prompts.js', () => ({
 	SYSTEM_PLAN: 'plan prompt',
 	SYSTEM_BUILD: 'build prompt',

--- a/src/llm/api.ts
+++ b/src/llm/api.ts
@@ -10,6 +10,7 @@ import GeneratedModel, { computeCost, type ApiUsage } from '../models/Generated.
 import { getMemoryContext } from '../agents/memory.js'
 import { getRecentLog } from '../tools/git.js'
 import { getLatestMainCoverage } from '../tools/github.js'
+import { getRecentIterationSummary } from '../agents/analyze.js'
 
 export type Phase = 'planner' | 'builder' | 'fixer' | 'reflect' | 'memory'
 
@@ -68,6 +69,10 @@ async function buildParams(phase: Phase, messages: Anthropic.MessageParam[], too
 		const unusedFunctions = await findUnusedFunctions(env.workspacePath)
 		if (unusedFunctions) {
 			system.push({ type: 'text', text: `\n\n## Unused Functions\n${unusedFunctions}` })
+		}
+		const iterationSummary = await getRecentIterationSummary()
+		if (iterationSummary) {
+			system.push({ type: 'text', text: `\n\n## Recent Iteration Outcomes\n${iterationSummary}` })
 		}
 	}
 


### PR DESCRIPTION
Add a summary of recent iteration outcomes to the planner's system prompt context. This provides immediate visibility into success/failure patterns without requiring tool calls, complementing the existing reflections with hard data about merge rates, fix attempts, and common failure modes from the last 10 iterations.